### PR TITLE
Fix pymongo compatability

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -20,7 +20,7 @@ from . import local  # noqa
 
 SERIES = 'cliffs'
 
-__version__ = '4.5.1'
+__version__ = '4.5.0.1'
 __author__ = 'Ask Solem'
 __contact__ = 'auvipy@gmail.com'
 __homepage__ = 'http://celeryproject.org'

--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -20,7 +20,7 @@ from . import local  # noqa
 
 SERIES = 'cliffs'
 
-__version__ = '4.5.0'
+__version__ = '4.5.1'
 __author__ = 'Ask Solem'
 __contact__ = 'auvipy@gmail.com'
 __homepage__ = 'http://celeryproject.org'

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -274,16 +274,7 @@ class MongoBackend(BaseBackend):
 
     def _get_database(self):
         conn = self._get_connection()
-        db = conn[self.database_name]
-        if self.user and self.password:
-            source = self.options.get(
-                'authsource',
-                self.database_name or 'admin'
-            )
-            if not db.authenticate(self.user, self.password, source=source):
-                raise ImproperlyConfigured(
-                    'Invalid MongoDB username or password.')
-        return db
+        return conn[self.database_name]
 
     @cached_property
     def database(self):

--- a/requirements/extras/mongodb.txt
+++ b/requirements/extras/mongodb.txt
@@ -1,1 +1,1 @@
-pymongo[srv]>=3.3.0
+pymongo[srv]>=3.11.1

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -277,8 +277,6 @@ class test_MongoBackend:
 
         assert database is mock_database
         assert self.backend.__dict__['database'] is mock_database
-        mock_database.authenticate.assert_called_once_with(
-            MONGODB_USER, MONGODB_PASSWORD, source=self.backend.database_name)
 
     @patch('celery.backends.mongodb.MongoBackend._get_connection')
     def test_get_database_no_existing_no_auth(self, mock_get_connection):
@@ -294,7 +292,6 @@ class test_MongoBackend:
         database = self.backend.database
 
         assert database is mock_database
-        mock_database.authenticate.assert_not_called()
         assert self.backend.__dict__['database'] is mock_database
 
     @patch('celery.backends.mongodb.MongoBackend._get_database')
@@ -487,18 +484,6 @@ class test_MongoBackend:
         mock_get_database.assert_called_once_with()
         mock_collection.delete_many.assert_called()
 
-    def test_get_database_authfailure(self):
-        x = MongoBackend(app=self.app)
-        x._get_connection = Mock()
-        conn = x._get_connection.return_value = {}
-        db = conn[x.database_name] = Mock()
-        db.authenticate.return_value = False
-        x.user = 'jerry'
-        x.password = 'cere4l'
-        with pytest.raises(ImproperlyConfigured):
-            x._get_database()
-        db.authenticate.assert_called_with('jerry', 'cere4l',
-                                           source=x.database_name)
 
     def test_prepare_client_options(self):
         with patch('pymongo.version_tuple', new=(3, 0, 3)):


### PR DESCRIPTION
## Background
This version of Celery is not supporting newer versions of `pymongo` (>3.5).

## Solution
Cherry picking the [commit](https://github.com/celery/celery/commit/398f2f75ae5a51d71238f5b540442e7ea23d1755) from the origin `celery`. 
Origin [PR](https://github.com/celery/celery/pull/7130)

## Test
TBD